### PR TITLE
Refactor blocking and queue updates to use game ticks (#1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.2.0'
+version = '1.2.1'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouch.java
+++ b/src/main/java/essencepouchtracking/EssencePouch.java
@@ -52,18 +52,22 @@ public class EssencePouch
 	 *
 	 * @param essenceToRemove the number of essence to remove from the pouch
 	 */
-	public void empty(int essenceToRemove)
+	public int empty(int essenceToRemove)
 	{
 		int previousStoredEssence = this.storedEssence;
-		this.storedEssence -= essenceToRemove;
+		int essenceRemoved = Math.min(essenceToRemove, this.storedEssence);
+		this.storedEssence -= essenceRemoved;
 		this.setUnknownStored(false);
-		log.debug("Removing {} essence, storing {}/{} essence into the {}. Previously stored {}/{} essence.",
+		log.debug("Asked to remove {} essence, removing {}, storing {}/{} essence into the {}. Previously stored {}/{} essence.",
 			essenceToRemove,
+			essenceRemoved,
 			this.storedEssence,
 			this.pouchType.getMaxCapacity(),
 			this.pouchType.getName(),
 			previousStoredEssence,
-			this.pouchType.getMaxCapacity());
+			this.pouchType.getMaxCapacity()
+		);
+		return essenceRemoved;
 	}
 
 	/**
@@ -87,7 +91,8 @@ public class EssencePouch
 			essenceToStore,
 			this.pouchType.getMaxCapacity(),
 			this.pouchType.getName(),
-			this.remainingEssenceBeforeDecay);
+			this.remainingEssenceBeforeDecay
+		);
 		// Left-over essence that exceeded maximum capacity
 		// Math.max(0, totalEssenceInInventory - this.pouchType.getMaxCapacity())
 		return essenceToStore;

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingOverlay.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingOverlay.java
@@ -73,7 +73,7 @@ public class EssencePouchTrackingOverlay extends WidgetItemOverlay
 		String remainingEssenceText;
 		if (!pouch.isDegraded())
 		{
-			if (remainingEssence < 0 || unknownState)
+			if (remainingEssence <= 0 || unknownState)
 			{
 				remainingEssenceText = "Repair";
 			}

--- a/src/main/java/essencepouchtracking/PouchActionTask.java
+++ b/src/main/java/essencepouchtracking/PouchActionTask.java
@@ -1,8 +1,8 @@
 package essencepouchtracking;
 
-import lombok.Getter;
+import lombok.Data;
 
-@Getter
+@Data
 public class PouchActionTask
 {
 	private EssencePouches pouchType;
@@ -12,6 +12,12 @@ public class PouchActionTask
 	{
 		this.pouchType = pouchType;
 		this.action = action.equalsIgnoreCase("Fill") ? PouchAction.FILL : PouchAction.EMPTY;
+	}
+
+	public PouchActionTask(PouchActionTask pouchActionTask)
+	{
+		this.pouchType = pouchActionTask.getPouchType();
+		this.action = pouchActionTask.getAction();
 	}
 
 	public enum PouchAction


### PR DESCRIPTION
- Add #handPouchActionsPostDegrade to handle updating state after a pouch degrades
	- Add self-constructor for PouchActionTask
	- Handle maximum removal amount within EssencePouch#empty

1. Fill small pouch
2. Fill giant pouch
3. Fill large pouch
4. Fill medium pouch

They all had correct stored amounts except for the medium pouch and it was listed as one. However, this could have been due to not emptying prior, I was seeing things, or it was just a rare instance.

I've been testing this for about 10 minutes now and am failing to recreate the _issue_ above and all the counts have been accurate.