### PR TITLE
Refactor load state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.2.3'
+version = '1.2.4'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -105,6 +105,8 @@ public class EssencePouchTrackingPlugin extends Plugin
 		this.overlayManager.add(overlay);
 		// Initialize the pouches
 		this.initializePouches();
+		// Load the tracking state
+		this.loadTrackingState();
 	}
 
 	@Override

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -103,8 +103,6 @@ public class EssencePouchTrackingPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		this.overlayManager.add(overlay);
-		// Initialize the pouches
-		this.initializePouches();
 		// Load the tracking state
 		this.loadTrackingState();
 	}
@@ -882,7 +880,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 		{
 			this.trackingState = trackingState;
 			log.debug("Loaded tracking state: {}", trackingState);
-			for (EssencePouches pouchType : this.pouches.keySet())
+			for (EssencePouches pouchType : EssencePouches.values())
 			{
 				this.pouches.put(pouchType, trackingState.getPouch(pouchType));
 			}
@@ -909,6 +907,11 @@ public class EssencePouchTrackingPlugin extends Plugin
 		{
 			log.debug("Unable to update the tracking state due to the state being null. Initializing the state.");
 			this.trackingState = new EssencePouchTrackingState();
+			// Initialize the pouches
+			for (EssencePouches pouch : EssencePouches.values())
+			{
+				this.pouches.put(pouch, new EssencePouch(pouch));
+			}
 		}
 		this.saveTrackingState();
 	}
@@ -933,13 +936,5 @@ public class EssencePouchTrackingPlugin extends Plugin
 	private EssencePouchTrackingState deserializeState(String serializedStateAsJSON)
 	{
 		return this.gson.fromJson(serializedStateAsJSON, EssencePouchTrackingState.class);
-	}
-
-	private void initializePouches()
-	{
-		for (EssencePouches pouch : EssencePouches.values())
-		{
-			this.pouches.put(pouch, new EssencePouch(pouch));
-		}
 	}
 }


### PR DESCRIPTION
- **Fixed an issue where the state was not being loaded after a user turns the plugin on**
	- Separate from first log-in
	- User is already logged in -> (Turns plugin off) -> Turns plugin on -> Previous state would not be loaded
- Remove EssencePouchTrackingPlugin#initializePouches since the method was being called once
- Moved `this.pouches` pouch map initialization into EssencePouchTrackingPlugin#updateTrackingState
- When loading the previous state, loop through every known essence pouch (`EssencePouches`) instead of just pouch map (`this.pouches`)