### PR TITLE
Fix incorrect state when RCing fast (#13)

### DIFF
--- a/src/main/java/essencepouchtracking/EssencePouch.java
+++ b/src/main/java/essencepouchtracking/EssencePouch.java
@@ -51,6 +51,7 @@ public class EssencePouch
 	 * Empties the specified amount of essence from the pouch
 	 *
 	 * @param essenceToRemove the number of essence to remove from the pouch
+	 * @return the number of essence that was removed from the pouch
 	 */
 	public int empty(int essenceToRemove)
 	{

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingDebugOverlay.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingDebugOverlay.java
@@ -44,8 +44,11 @@ public class EssencePouchTrackingDebugOverlay extends OverlayPanel
 
 //		boolean isPaused = (this.plugin.getPauseUntilTick() != -1 && this.client.getTickCount() > this.plugin.getPauseUntilTick());
 		boolean isPaused = !(this.plugin.getPauseUntilTick() == -1 || this.client.getTickCount() >= this.plugin.getPauseUntilTick());
+		boolean wasLastActionCraft = this.plugin.isWasLastActionCraftRune();
+
 		buildLine("Current Tick", String.valueOf(this.client.getTickCount()));
 		buildLine("Updates Paused?", String.valueOf(isPaused) + " (" + this.plugin.getPauseUntilTick() + ")");
+		buildLine("Crafted?", String.valueOf(wasLastActionCraft));
 		buildLine("", "");
 		buildLine("Prev Free Slot", String.valueOf(previousInventoryFreeSlots));
 		buildLine("Free Slot", String.valueOf(inventoryFreeSlots));

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingDebugOverlay.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingDebugOverlay.java
@@ -1,0 +1,75 @@
+package essencepouchtracking;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.util.Deque;
+import java.util.Map;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+
+@Slf4j
+public class EssencePouchTrackingDebugOverlay extends OverlayPanel
+{
+	private final EssencePouchTrackingPlugin plugin;
+	private final EssencePouchTrackingConfig config;
+	private final Client client;
+
+	@Inject
+	private EssencePouchTrackingDebugOverlay(EssencePouchTrackingPlugin plugin, EssencePouchTrackingConfig config, Client client)
+	{
+		super(plugin);
+		this.plugin = plugin;
+		this.config = config;
+		this.client = client;
+		setPosition(OverlayPosition.BOTTOM_RIGHT);
+		setPriority(PRIORITY_MED);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		Map<EssencePouches, EssencePouch> pouches = this.plugin.getPouches();
+		Deque<PouchActionTask> pouchTaskQueue = this.plugin.getPouchTaskQueue();
+		int previousEssenceInInventory = this.plugin.getPreviousEssenceInInventory();
+		int essenceInInventory = this.plugin.getEssenceInInventory();
+
+		int previousInventoryFreeSlots = this.plugin.getPreviousInventoryFreeSlots();
+		int inventoryFreeSlots = this.plugin.getInventoryFreeSlots();
+		int previousInventoryUsedSlots = this.plugin.getPreviousInventoryUsedSlots();
+		int inventoryUsedSlots = this.plugin.getInventoryUsedSlots();
+
+//		boolean isPaused = (this.plugin.getPauseUntilTick() != -1 && this.client.getTickCount() > this.plugin.getPauseUntilTick());
+		boolean isPaused = !(this.plugin.getPauseUntilTick() == -1 || this.client.getTickCount() >= this.plugin.getPauseUntilTick());
+		buildLine("Current Tick", String.valueOf(this.client.getTickCount()));
+		buildLine("Updates Paused?", String.valueOf(isPaused) + " (" + this.plugin.getPauseUntilTick() + ")");
+		buildLine("", "");
+		buildLine("Prev Free Slot", String.valueOf(previousInventoryFreeSlots));
+		buildLine("Free Slot", String.valueOf(inventoryFreeSlots));
+		buildLine("Prev Used Slot", String.valueOf(previousInventoryUsedSlots));
+		buildLine("Used Slot", String.valueOf(inventoryUsedSlots));
+		buildLine("Prev Essence", String.valueOf(previousEssenceInInventory));
+		buildLine("Essence", String.valueOf(essenceInInventory));
+		buildLine("", "");
+		int q = 1;
+		for (PouchActionTask pouch : pouchTaskQueue)
+		{
+			buildLine(String.valueOf(q++), pouch.toString());
+		}
+		buildLine("", "");
+		for (Map.Entry<EssencePouches, EssencePouch> entry : pouches.entrySet())
+		{
+			EssencePouch pouch = entry.getValue();
+			buildLine(entry.getKey().toString(), String.valueOf(pouch.getStoredEssence()));
+		}
+		return super.render(graphics);
+	}
+
+	private void buildLine(String left, String right)
+	{
+		panelComponent.getChildren().add(LineComponent.builder().left(left).right(right).build());
+	}
+}

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -298,6 +298,25 @@ public class EssencePouchTrackingPlugin extends Plugin
 			this.lastCraftRuneTick = this.client.getTickCount();
 			this.pouchTaskQueue.clear();
 		}
+
+		if (menuOptionClicked.getMenuAction().equals(MenuAction.WIDGET_TARGET_ON_GAME_OBJECT))
+		{
+			if (menuOptionClicked.getMenuOption().equalsIgnoreCase("use") && menuOptionClicked.getMenuTarget().endsWith("Altar"))
+			{
+				if (this.client.isWidgetSelected())
+				{
+					int selectedItemID = this.client.getSelectedWidget().getItemId();
+					if (selectedItemID != -1 && this.itemManager.getItemComposition(selectedItemID).getName().endsWith("rune"))
+					{
+						// Player has interacted with an Altar using a rune (attempting to craft combination runes)
+						// Handle the state change after the experience drop which confirms the craft
+						this.wasLastActionCraftRune = true;
+						this.lastCraftRuneTick = this.client.getTickCount();
+						this.pouchTaskQueue.clear();
+					}
+				}
+			}
+		}
 	}
 
 	public boolean onPouchActionCreated(PouchActionCreated createdPouchAction)

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -316,10 +316,10 @@ public class EssencePouchTrackingPlugin extends Plugin
 			// We meet all the conditions required to fill the pouch with essence (we have essence and the pouch isn't full)
 			int essencePutIntoThePouch = pouch.fill(this.essenceInInventory);
 			log.debug("Added {} essence to the pouch for a total of {}/{}", essencePutIntoThePouch, pouch.getStoredEssence(), pouch.getMaximumCapacity());
+			this.updatePreviousInventoryDetails();
 			this.essenceInInventory -= essencePutIntoThePouch;
 			this.inventoryUsedSlots -= essencePutIntoThePouch;
 			this.inventoryFreeSlots += essencePutIntoThePouch;
-			this.updatePreviousInventoryDetails();
 		}
 		else
 		{
@@ -339,10 +339,10 @@ public class EssencePouchTrackingPlugin extends Plugin
 			// Find out how much essence we can take out of the pouch
 			int essenceEmptied = pouch.empty(this.inventoryFreeSlots);
 			log.debug("Removed {} essence from the pouch for a total of {}/{}", essenceEmptied, pouch.getStoredEssence(), pouch.getMaximumCapacity());
+			this.updatePreviousInventoryDetails();
 			this.essenceInInventory += essenceEmptied;
 			this.inventoryUsedSlots += essenceEmptied;
 			this.inventoryFreeSlots -= essenceEmptied;
-			this.updatePreviousInventoryDetails();
 		}
 		log.debug("[Inventory Data] After | Essence in inventory: {}, Free slots: {}, Used slots: {}", this.essenceInInventory, this.inventoryFreeSlots, this.inventoryUsedSlots);
 		// blockUpdate = false;
@@ -359,20 +359,20 @@ public class EssencePouchTrackingPlugin extends Plugin
 		{
 			// Depositing the essence from the players inventory into the bank
 			// Don't worry about the quantity being invalid because this was calculated in onMenuOptionClicked
+			this.updatePreviousInventoryDetails();
 			this.essenceInInventory -= createdBankEssenceTask.getQuantity();
 			this.inventoryUsedSlots -= createdBankEssenceTask.getQuantity();
 			this.inventoryFreeSlots += createdBankEssenceTask.getQuantity();
-			this.updatePreviousInventoryDetails();
 		}
 		else
 		{
 			// Withdrawing the essence from the players bank into their inventory
 			// Remember to check the quantity because the quantity was assigned by the # of the item we have in the bank
 			int maximumEssenceAvailableToWithdraw = Math.min(createdBankEssenceTask.getQuantity(), this.inventoryFreeSlots);
+			this.updatePreviousInventoryDetails();
 			this.essenceInInventory += maximumEssenceAvailableToWithdraw;
 			this.inventoryUsedSlots += maximumEssenceAvailableToWithdraw;
 			this.inventoryFreeSlots -= maximumEssenceAvailableToWithdraw;
-			this.updatePreviousInventoryDetails();
 		}
 		log.debug("[Inventory Data] After | Essence in inventory: {}, Free slots: {}, Used slots: {}", this.essenceInInventory, this.inventoryFreeSlots, this.inventoryUsedSlots);
 	}
@@ -388,8 +388,8 @@ public class EssencePouchTrackingPlugin extends Plugin
 			itemStream.forEach(item -> this.currentInventoryItems.add(item.getId(), this.itemManager.getItemComposition(item.getId()).isStackable() ? 1 : item.getQuantity()));
 			if (this.pauseUntilTick == -1 || this.client.getTickCount() >= this.pauseUntilTick)
 			{
+				this.updatePreviousInventoryDetails();
 				this.essenceInInventory = 0;
-				updatePreviousInventoryDetails();
 				itemStream.stream().filter(item -> this.isValidEssencePouchItem(item.getId())).forEach(item -> this.essenceInInventory++);
 				this.inventoryUsedSlots = this.currentInventoryItems.size();
 				this.inventoryFreeSlots = 28 - this.inventoryUsedSlots;
@@ -573,6 +573,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 					pouch.setUnknownStored(false);
 					pouch.setStoredEssence(numberOfEssence);
 				}
+				this.updateTrackingState();
 			}
 			else
 			{
@@ -838,10 +839,10 @@ public class EssencePouchTrackingPlugin extends Plugin
 				int numberOfEssenceEmptied = degradedPouch.empty(this.inventoryFreeSlots);
 				degradedPouch.setRemainingEssenceBeforeDecay(degradedPouch.getRemainingEssenceBeforeDecay() + numberOfEssenceEmptied);
 				log.debug("Re-removing {} essence from the now-degraded pouch for a total of {}/{}", numberOfEssenceEmptied, degradedPouch.getStoredEssence(), degradedPouch.getMaximumCapacity());
+				this.updatePreviousInventoryDetails();
 				this.essenceInInventory += numberOfEssenceEmptied;
 				this.inventoryUsedSlots += numberOfEssenceEmptied;
 				this.inventoryFreeSlots -= numberOfEssenceEmptied;
-				this.updatePreviousInventoryDetails();
 				// Now that the pouch has been emptied out, we can re-fill it
 				PouchActionTask pouchFilLAction = new PouchActionTask(degradedPouch.getPouchType(), "Fill");
 				onPouchActionCreated(new PouchActionCreated(pouchFilLAction));
@@ -852,10 +853,10 @@ public class EssencePouchTrackingPlugin extends Plugin
 				int numberOfEssenceRestored = degradedPouch.fill(this.essenceInInventory);
 				degradedPouch.setRemainingEssenceBeforeDecay(degradedPouch.getRemainingEssenceBeforeDecay() - numberOfEssenceRestored);
 				log.debug("Restoring {} essence to the pouch for a total of {}/{}", numberOfEssenceRestored, degradedPouch.getStoredEssence(), degradedPouch.getMaximumCapacity());
+				this.updatePreviousInventoryDetails();
 				this.essenceInInventory -= numberOfEssenceRestored;
 				this.inventoryUsedSlots -= numberOfEssenceRestored;
 				this.inventoryFreeSlots += numberOfEssenceRestored;
-				this.updatePreviousInventoryDetails();
 				// Now that the pouch has been re-filled out, we can re-fill it
 				PouchActionTask pouchFilLEmpty = new PouchActionTask(degradedPouch.getPouchType(), "Empty");
 				onPouchActionCreated(new PouchActionCreated(pouchFilLEmpty));

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -77,21 +77,29 @@ public class EssencePouchTrackingPlugin extends Plugin
 	@Inject
 	private EssencePouchTrackingOverlay overlay;
 
+	@Inject
+	private EssencePouchTrackingDebugOverlay debugOverlay;
+
 	private EssencePouchTrackingState trackingState;
 
 	@Getter
 	private final Map<EssencePouches, EssencePouch> pouches = new HashMap<>();
+	@Getter
 	private final Deque<PouchActionTask> pouchTaskQueue = Queues.newArrayDeque();
 	private final Deque<EssencePouch> checkedPouchQueue = Queues.newArrayDeque();
 	private Multiset<Integer> previousInventory = HashMultiset.create();
-
-	private boolean isRepairDialogue;
-
 	private Multiset<Integer> currentInventoryItems = HashMultiset.create();
+
+	@Getter
 	private int previousEssenceInInventory, essenceInInventory;
+	@Getter
 	private int previousInventoryFreeSlots, inventoryFreeSlots;
+	@Getter
 	private int previousInventoryUsedSlots, inventoryUsedSlots;
+
+	@Getter
 	private int pauseUntilTick;
+	private boolean isRepairDialogue;
 
 	@Provides
 	EssencePouchTrackingConfig provideConfig(ConfigManager configManager)
@@ -103,6 +111,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		this.overlayManager.add(overlay);
+		this.overlayManager.add(debugOverlay);
 		// Load the tracking state
 		this.loadTrackingState();
 	}
@@ -120,6 +129,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 		this.previousInventoryFreeSlots = this.inventoryFreeSlots = 0;
 		this.previousInventoryUsedSlots = this.inventoryUsedSlots = 0;
 		this.overlayManager.remove(overlay);
+		this.overlayManager.remove(debugOverlay);
 		this.pauseUntilTick = 0;
 	}
 

--- a/src/main/java/essencepouchtracking/PouchActionTask.java
+++ b/src/main/java/essencepouchtracking/PouchActionTask.java
@@ -7,11 +7,13 @@ public class PouchActionTask
 {
 	private EssencePouches pouchType;
 	private PouchAction action;
+	private int createdAtGameTick;
 
-	public PouchActionTask(EssencePouches pouchType, String action)
+	public PouchActionTask(EssencePouches pouchType, String action, int createdAtGameTick)
 	{
 		this.pouchType = pouchType;
 		this.action = action.equalsIgnoreCase("Fill") ? PouchAction.FILL : PouchAction.EMPTY;
+		this.createdAtGameTick = createdAtGameTick;
 	}
 
 	public PouchActionTask(PouchActionTask pouchActionTask)


### PR DESCRIPTION
- Track when user is crafting runes to manually handle pouch and inventory state
	- Listening for StatChanged and FakeXpDrop to determine if a player crafted runes
	- Primarily for emptying pouches as that's where the issue was occuring where stored essence was incorrect
	- Tracks when a user runecrafts and added properties to track the last craft action and it's tick
- Revert change that added all tasks to the PouchActionTask queue
	- Only add to the queue if the pouch task was successful
- Added logic to handle rune crafting by checking menu actions and confirming successful crafting via XP drops.
- Changed to use injected `developerMode` instead of self-defined variable
- Only render debug overlay when on dev mode

- Moved #updatePreviousInventoryDetails call before modifying current inventory properties for proper sequence
- Adjusted tracking state to update when pouches are checked

- Added a debugging overlay panel when in dev mode to help with debugging inventory state
	- Primarily useful for recording footage and slowing it down since the interactions that cause incorrect state happen faster than game ticks so <600ms and it's hard to notice without recording and slowing down.

- Add `createdAtGameTick` to PouchActionTask to track when pouch action tasks were created
- Add a pouch action task to the task queue when in the middle of runecrafting as well
- Clear the current task queue when interacting to craft runes as those actions are invalid now
- Clear the task queue if the task expired as those actions are invalid now
- Refactor FakeXpDrop and StatChanged events task queue initialization (removed filters) and processing
	- Add all current PouchActionTasks to the temporary queue (empty/fill)
	- Process actions by using PouchActionCreated events

- Fix issue where crafting combination runes weren't being handled
	- Added craft-rune menu option handling

Fixes #13 