### PR TITLE
Fixes #17, Re-add the degraded pouch task to the temp queue

### DIFF
--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -851,6 +851,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 				onPouchActionCreated(new PouchActionCreated(pouchFilLEmpty));
 			}
 		}
+		tempActionQueue.addFirst(task);
 		log.debug("After Temp Pouch Task Queue: {}", tempActionQueue);
 
 		// Now re-do the tasks


### PR DESCRIPTION
ATP the degraded pouch task was removed with the last poll call. These changes appropriately re-adds the task to the front of the queue as expected to be re-ran.

Not sure how I missed this or even accepted the changes in the first place claiming it was fixed, because it wasn't. 