### PR TITLE
Fixes #19: Ignore check pouch for successful pouch actions

### DIFF
--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -192,7 +192,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 	public void onMenuOptionClicked(MenuOptionClicked menuOptionClicked)
 	{
 		log.debug("{}", menuOptionClicked);
-		log.debug("[Inventory Data] MenuOptionClicked Inventory | Essence in inventory: {}->{}, Free slots: {}->{}, Used slots: {}->{}",
+		log.debug("[Inventory Data] MenuOptionClicked MenuOption | Essence in inventory: {}->{}, Free slots: {}->{}, Used slots: {}->{}",
 			this.previousEssenceInInventory, this.essenceInInventory,
 			this.previousInventoryFreeSlots, this.inventoryFreeSlots,
 			this.previousInventoryUsedSlots, this.inventoryUsedSlots
@@ -731,6 +731,17 @@ public class EssencePouchTrackingPlugin extends Plugin
 			}
 			if (pouch != null)
 			{
+				for (PouchActionTask taskAction : this.pouchTaskQueue)
+				{
+					if (taskAction.getPouchType().equals(pouch.getPouchType()))
+					{
+						if (taskAction.wasSuccessful())
+						{
+							log.debug("Pouch action for {} was successful therefore ignoring pouch check result.", pouch.getPouchType());
+							return;
+						}
+					}
+				}
 				int previousStoredEssence = pouch.getStoredEssence();
 				int difference = numberOfEssence - previousStoredEssence;
 

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -277,6 +277,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 					boolean wasActionSuccessful = onPouchActionCreated(new PouchActionCreated(pouchTask));
 					if (wasActionSuccessful || this.lastCraftRuneTick != -1)
 					{
+						pouchTask.setWasSuccessful(wasActionSuccessful);
 						this.pouchTaskQueue.add(pouchTask);
 						log.debug("Added {} task to queue: {}", pouchTask, this.pouchTaskQueue);
 					}
@@ -717,6 +718,17 @@ public class EssencePouchTrackingPlugin extends Plugin
 		{
 			int numberOfEssence = EssencePouches.checkEssenceStringToInt(message);
 			EssencePouch pouch = this.checkedPouchQueue.poll();
+			for (PouchActionTask taskAction : this.pouchTaskQueue)
+			{
+				if (taskAction.getPouchType().equals(pouch.getPouchType()))
+				{
+					if (taskAction.wasSuccessful())
+					{
+						log.debug("Pouch action for {} was successful therefore ignoring pouch check result.", pouch.getPouchType());
+						return;
+					}
+				}
+			}
 			if (pouch != null)
 			{
 				int previousStoredEssence = pouch.getStoredEssence();

--- a/src/main/java/essencepouchtracking/PouchActionTask.java
+++ b/src/main/java/essencepouchtracking/PouchActionTask.java
@@ -8,12 +8,20 @@ public class PouchActionTask
 	private EssencePouches pouchType;
 	private PouchAction action;
 	private int createdAtGameTick;
+	private boolean wasSuccessful;
+
+	public enum PouchAction
+	{
+		FILL,
+		EMPTY
+	}
 
 	public PouchActionTask(EssencePouches pouchType, String action, int createdAtGameTick)
 	{
 		this.pouchType = pouchType;
 		this.action = action.equalsIgnoreCase("Fill") ? PouchAction.FILL : PouchAction.EMPTY;
 		this.createdAtGameTick = createdAtGameTick;
+		this.wasSuccessful = false;
 	}
 
 	public PouchActionTask(PouchActionTask pouchActionTask)
@@ -22,10 +30,14 @@ public class PouchActionTask
 		this.action = pouchActionTask.getAction();
 	}
 
-	public enum PouchAction
+	public boolean wasSuccessful()
 	{
-		FILL,
-		EMPTY
+		return this.wasSuccessful;
+	}
+
+	public void setWasSuccessful(boolean successful)
+	{
+		this.wasSuccessful = successful;
 	}
 
 	@Override


### PR DESCRIPTION
The following changes makes it so that if you check a pouch and then do an action on it, that the state updates from the incoming chat message will be ignored **if and only if the pouch action was completed successfully**
- Add `wasSuccessful` property to PouchActionTask
- Ignore successful pouches from having their state overridden by a check pouch