### PR TITLE
Add additional support for Dark Mage pouch decay and checking

### DIFF
--- a/src/main/java/essencepouchtracking/EssencePouch.java
+++ b/src/main/java/essencepouchtracking/EssencePouch.java
@@ -45,6 +45,7 @@ public class EssencePouch
 		this.remainingEssenceBeforeDecay = this.pouchType.getMaxEssenceBeforeDecay();
 		this.setDegraded(false);
 		this.setUnknownDecay(false);
+		log.debug("Repaired {} back to {} remaining essence before decay.", this.pouchType.getName(), this.pouchType.getMaxEssenceBeforeDecay());
 	}
 
 	/**

--- a/src/main/java/essencepouchtracking/EssencePouch.java
+++ b/src/main/java/essencepouchtracking/EssencePouch.java
@@ -115,7 +115,7 @@ public class EssencePouch
 	{
 		if (this.shouldDegrade)
 		{
-			return this.remainingEssenceBeforeDecay / this.pouchType.getMaxEssenceBeforeDecay();
+			return this.unknownDecay ? Double.MIN_NORMAL : this.remainingEssenceBeforeDecay / this.pouchType.getMaxEssenceBeforeDecay();
 		}
 		else
 		{

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -109,8 +109,11 @@ public class EssencePouchTrackingPlugin extends Plugin
 	@Getter
 	private int pauseUntilTick;
 	private boolean isRepairDialogue;
-	List<String> ALREADY_REPAIRED_DIALOG_OPTIONS = ImmutableList.of("Select an option", "Can I have another Abyssal book?", "Actually, I don't need anything right now.", "", "");
-	List<String> POST_REPAIR_DIALOG_OPTIONS = ImmutableList.of("Select an option", "Can I have another Abyssal book?", "Thanks.", "", "");
+	private final List<String> ALREADY_REPAIRED_DIALOG_OPTIONS = ImmutableList.of("Select an option", "Can I have another Abyssal book?", "Actually, I don't need anything right now.", "", "");
+	private final List<String> POST_REPAIR_DIALOG_OPTIONS = ImmutableList.of("Select an option", "Can I have another Abyssal book?", "Thanks.", "", "");
+	private final List<String> POST_REPAIR_DARK_MAGE_DIALOG_TEXT = ImmutableList.of("Fine. A simple transfiguration spell should resolve things<br>for you.", "There, I have repaired your pouches. Now leave me<br>alone. I'm concentrating!", "You don't seem to have any pouches in need of repair.<br>Leave me alone!");
+	private final String REQUEST_REPAIR_PLAYER_DIALOG_TEXT = "Can you repair my pouches?";
+	private final String DIALOG_CONTINUE_TEXT = "Click here to continue";
 
 	// Last action of the tick
 	@Getter
@@ -331,7 +334,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 		{
 			Widget clickedWidget = menuOptionClicked.getWidget();
 			Widget dialogPlayerTextWidget = this.client.getWidget(ComponentID.DIALOG_PLAYER_TEXT);
-			if (clickedWidget != null && dialogPlayerTextWidget != null && clickedWidget.getText().equals("Click here to continue") && dialogPlayerTextWidget.getText().equals("Can you repair my pouches?"))
+			if (clickedWidget != null && dialogPlayerTextWidget != null && clickedWidget.getText().equals(DIALOG_CONTINUE_TEXT) && dialogPlayerTextWidget.getText().equals(REQUEST_REPAIR_PLAYER_DIALOG_TEXT))
 			{
 				this.repairAllPouches();
 			}
@@ -554,10 +557,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 			if (dialogNPCHeadModel != null && dialogNPCHeadModel.getModelId() == NpcID.DARK_MAGE)
 			{
 				Widget dialogText = this.client.getWidget(ComponentID.DIALOG_NPC_TEXT);
-				if (dialogText != null &&
-					(dialogText.getText().equals("Fine. A simple transfiguration spell should resolve things<br>for you.")
-						|| dialogText.getText().equals("There, I have repaired your pouches. Now leave me<br>alone. I'm concentrating!")
-						|| dialogText.getText().equals("You don't seem to have any pouches in need of repair.<br>Leave me alone!")))
+				if (dialogText != null && POST_REPAIR_DARK_MAGE_DIALOG_TEXT.contains(dialogText.getText()))
 				{
 					this.repairAllPouches();
 				}
@@ -931,7 +931,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 		if (this.isRepairDialogue && postFiredScript.getScriptId() == 2153)
 		{
 			Widget dialogPlayerTextWidget = this.client.getWidget(ComponentID.DIALOG_PLAYER_TEXT);
-			if (dialogPlayerTextWidget != null && dialogPlayerTextWidget.getText().equals("Can you repair my pouches?"))
+			if (dialogPlayerTextWidget != null && dialogPlayerTextWidget.getText().equals(REQUEST_REPAIR_PLAYER_DIALOG_TEXT))
 			{
 				this.repairAllPouches();
 			}
@@ -1211,7 +1211,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 		boolean repaired = false;
 		for (EssencePouch pouch : this.pouches.values())
 		{
-			if (pouch.getApproximateFillsLeft() != 1.0)
+			if (pouch.getApproximateFillsLeft() != 1.0 || pouch.isUnknownDecay())
 			{
 				pouch.repairPouch();
 				repaired = true;

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -574,21 +574,6 @@ public class EssencePouchTrackingPlugin extends Plugin
 					this.repairAllPouches();
 				}
 			}
-
-			// Check to see if the player is in the dialogue with the Dark Mage to repair pouches
-			// Specifically, check to see if the player is asking for pouches to be repaired, and they "Continued" to repair
-			Widget dialogPlayerTextWidget = this.client.getWidget(ComponentID.DIALOG_PLAYER_TEXT);
-			if (dialogPlayerTextWidget != null && dialogPlayerTextWidget.getText().equals("Can you repair my pouches?"))
-			{
-				for (Widget widget : dialogPlayerTextWidget.getParent().getStaticChildren())
-				{
-					if (widget.getText().equals("Please wait..."))
-					{
-						this.repairAllPouches();
-						break;
-					}
-				}
-			}
 		}
 	}
 

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -325,6 +325,21 @@ public class EssencePouchTrackingPlugin extends Plugin
 				}
 			}
 		}
+
+		// WIDGET_CONTINUE is for when a player clicks an option on a dialog which includes "Click here to continue"
+		if (menuOptionClicked.getMenuAction().equals(MenuAction.WIDGET_CONTINUE))
+		{
+			Widget clickedWidget = menuOptionClicked.getWidget();
+			Widget dialogPlayerTextWidget = this.client.getWidget(ComponentID.DIALOG_PLAYER_TEXT);
+			if (clickedWidget != null && dialogPlayerTextWidget != null && clickedWidget.getText().equals("Click here to continue") && dialogPlayerTextWidget.getText().equals("Can you repair my pouches?"))
+			{
+				log.debug("Pouches have been repaired via menuoption");
+				this.pouches.values().forEach(EssencePouch::repairPouch);
+				log.debug("{}", this.pouches.values());
+				this.isRepairDialogue = false;
+				this.saveTrackingState();
+			}
+		}
 	}
 
 	public boolean onPouchActionCreated(PouchActionCreated createdPouchAction)
@@ -938,6 +953,22 @@ public class EssencePouchTrackingPlugin extends Plugin
 				log.debug("The input dialogue was not an integer for some reason \"{}\"", this.client.getVarcStrValue(VarClientStr.INPUT_TEXT));
 			}
 			this.bankEssenceTask = null;
+		}
+
+		// 2153 proc,chatbox_keyinput_matched any key pressed matched with the input dialog
+		// So for example space bar to "Click here to continue" or a number key associated with the menu option
+		// Didn't seem to fire for some input dialogs like the threshold to re-enable running or ESC
+		if (this.isRepairDialogue && postFiredScript.getScriptId() == 2153)
+		{
+			Widget dialogPlayerTextWidget = this.client.getWidget(ComponentID.DIALOG_PLAYER_TEXT);
+			if (dialogPlayerTextWidget != null && dialogPlayerTextWidget.getText().equals("Can you repair my pouches?"))
+			{
+				log.debug("Pouches have been repaired via script");
+				this.pouches.values().forEach(EssencePouch::repairPouch);
+				log.debug("{}", this.pouches.values());
+				this.isRepairDialogue = false;
+				this.saveTrackingState();
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds support for additional pouch decay and repair checks via the Dark Mage. 

- Auto-verify non-broken pouches (closes #3)
	- Add support for already repaired pouches via the repair dialog
- Add support for Dark Mage -> Repair MenuOption Dialog
- Add basic support for quickly repair and not finishing the dialog
	- Not consistent if the dialog finishes or exists faster than a tick