### PR TITLE
feat: Add GOTR pouch repair via Apprentice Cordelia

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.3.3'
+version = '1.4.0'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'


### PR DESCRIPTION
Adds support for repairing/decay checks through the GOTR NPC [Apprentice Cordelia](https://oldschool.runescape.wiki/w/Apprentice_Cordelia#Raiments_of_the_Eye)

- Add dialog checks for Cordelia pouch repair
	- MenuOption, CS2 Script, and dialog via GameTick


_Forgot to push this commit alongside #27 so this version update to `1.4.0` was a result of both Dark Mage and Cordelia changes._