### PR TITLE
Add support for decay prevention via specialized equipment (#9)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.4.0'
+version = '1.5.0'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouch.java
+++ b/src/main/java/essencepouchtracking/EssencePouch.java
@@ -76,14 +76,15 @@ public class EssencePouch
 	 * Fills the pouch with essence until it's full or as much essence that was given
 	 *
 	 * @param totalEssenceInInventory
+	 * @param ignoreDecay             should the pouch ignore decay when filling such as when wearing specialized equipment that prevents decay
 	 * @return the number of essence that stored within the pouch
 	 * Example: totalEssenceInInventory=10, storedEssence=3, getMaximumCapacity()=12 => return 1 (10+3 = 13 - 12 = 1 left over)
 	 */
-	public int fill(int totalEssenceInInventory)
+	public int fill(int totalEssenceInInventory, boolean ignoreDecay)
 	{
 		int essenceToStore = Math.min(totalEssenceInInventory, this.getAvailableSpace());
 		this.storedEssence += essenceToStore;
-		if (this.shouldDegrade)
+		if (this.shouldDegrade && !ignoreDecay)
 		{
 			this.remainingEssenceBeforeDecay -= essenceToStore;
 		}


### PR DESCRIPTION
- Adds support for disabling pouch decay when filling the pouch with Runecrafting cape or a variation of the Max Cape equipped
- Adds support for disabling pouch decay when filling the pouch with an Abyssal Lantern (redwood lantern) equipped when you're inside the GOTR minigame
	- The lantern is active only preventing decay while the player is inside active minigame area (passing the barrier into the minigame)
		- ~~Haven't tested if it only works when a game is active~~
		- https://discord.com/channels/301497432909414422/448811926315728896/1300645269771124767

Closes #9