### PR TITLE
Fixed wrong lantern state by tracking equipped vs inventory separately

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.0'
+version = '1.5.1'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'


### PR DESCRIPTION
There was an issue with v1.5.0 after adding support for decay prevention gear such as always thinking the player has a lantern. This fixes that.

- Track two different states for the abyssal lantern - equipped or in inventory
	- Refactored `hasRedwoodAbyssalLantern` into `hasRedwoodAbyssalLanternEquipped` and `hasRedwoodAbyssalLanternInInventory`
	- Added #hasRedwoodAbyssalLantern helper method
	- Refactor ItemContainerChanged event to set the new abyssal lantern properties appropriately

# Manual Tests
Initial login
- [x] Decays outside with no lantern or cape
- [x] Decays outside with lantern
- [x] Decays outside with lantern equipped
- [x] Doesn't decay outside with cape
- [x] Doesn't decay outside with lantern and cape

Pass the barrier
- [x] Decays inside pre-active rift with no lantern or cape
- [x] Decays inside pre-active rift with lantern
- [x] Decays inside pre-active rift with lantern equipped
- [x] Doesn't decay inside pre-active rift with cape
- [x] Doesn't decay inside post-active rift with lantern
- [x] Doesn't decay inside post-active rift with lantern equipped
- [x] Doesn't decay inside post-active rift with cape only
- [x] Doesn't decay inside post-active rift with lantern and cape

Pass the barrier and post match
- [x] Decay prevention still active pre-active rift

Pass the barrier and next game
- [x] Decay prevention still active pre-active rift
- [x] Decay prevention still active post-active rift
- [x] Extinguish lantern pre-active rift and decay prevention should be disabled
- [x] Extinguish lantern and equip cape pre-active rift and decay prevention should be enabled

Repeat the following after leaving the game
- [x] Decays outside with no lantern or cape
- [x] Decays outside with lantern
- [x] Decays outside with lantern equipped
- [x] Doesn't decay outside with cape
- [x] Doesn't decay outside with lantern and cape