### PR TITLE
fix: Updated init. plugin & tracking state on start/reset, fix GOTR Varbit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.1'
+version = '1.5.2'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -209,8 +209,9 @@ public class EssencePouchTrackingPlugin extends Plugin
 	public void resetConfiguration()
 	{
 		log.debug("Resetting the plugin and tracking states");
-		this.resetTrackingState();
+		// First reset plugin state followed by tracking state in order to initialize all pouches back into this.pouches
 		this.resetPluginState();
+		this.resetTrackingState();
 		this.clientThread.invokeLater(() -> {
 			if (this.client.getGameState().equals(GameState.LOGGED_IN))
 			{
@@ -1328,13 +1329,9 @@ public class EssencePouchTrackingPlugin extends Plugin
 
 	private void resetTrackingState()
 	{
-		log.debug("Resetting tracking state");
-		this.trackingState = new EssencePouchTrackingState();
-		for (EssencePouch pouch : this.pouches.values())
-		{
-			this.updatePouchFromState(pouch);
-		}
-		this.saveTrackingState();
+		log.debug("Resetting tracking state via #updateTrackingState");
+		this.trackingState = null;
+		this.updateTrackingState();
 	}
 
 	private void resetPluginState()


### PR DESCRIPTION
# Summary
This PR aims to fix some of the issues listed in #32 where certain cases don't initialize the plugin properly primarily when enabling/installing the plugin while a player is already logged in.
- Fixes the issue of ignoring pouch repairs within GOTR via Cordelia due to `didUnlockGOTRRepair` not being initialized when a player enables/installs the plugin while they're already logged in
- Fixes wrong `hasRedwoodAbyssalLantern` and `isCapeDecayPreventionActive` flags when resetting the plugin as resets don't re-fire inventory/equipment container changed events

Hopefully this covers all of the potential invalid stat problems due to first-starting the plugin when logged in.

# Code changes
- Load the pouch tracking state again on #startUp
- Refactor #resetConfiguration
	- Use #resetTrackingState and #resetPluginState
	- Send ItemContainerChanged events for inventory/equipment in #resetConfiguration to reinit state
- Update didUnlockGOTRRepair within #resetConfiguration and #startUp
	- Fixes issue where decay status isn't being updated when repaired via GOTR's Cordelia if you enable/install the plugin while logged in
- Use existing pouch from the current tracking state instead of creating a new pouch each time in #updateTrackingState
- Added #resetTrackingState to reset and save the pouch tracking state