### PR TITLE
refactor: pouches map should reflect current pouches in inventory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.2'
+version = '1.5.3'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingOverlay.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingOverlay.java
@@ -38,10 +38,9 @@ public class EssencePouchTrackingOverlay extends WidgetItemOverlay
 			return;
 		}
 
-		EssencePouch pouch = pouches.get(EssencePouches.getPouch(itemId));
+		EssencePouch pouch = this.plugin.getTrackingState().getPouch(itemId);
 		if (pouch != null)
 		{
-
 			if (this.config.showStoredEssence())
 			{
 				renderStoredEssence(graphics, itemId, widgetItem, pouch);

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -1362,8 +1362,9 @@ public class EssencePouchTrackingPlugin extends Plugin
 	private void repairAllPouches()
 	{
 		boolean repaired = false;
-		for (EssencePouch pouch : this.pouches.values())
+		for (EssencePouches pouchType : EssencePouches.values())
 		{
+			EssencePouch pouch = this.trackingState.getPouch(pouchType);
 			if (pouch.getApproximateFillsLeft() != 1.0 || pouch.isUnknownDecay())
 			{
 				pouch.repairPouch();

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -98,6 +98,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 	@Named("developerMode")
 	boolean developerMode;
 
+	@Getter
 	private EssencePouchTrackingState trackingState;
 
 	@Getter
@@ -592,6 +593,13 @@ public class EssencePouchTrackingPlugin extends Plugin
 				this.hasRedwoodAbyssalLanternInInventory = false;
 				log.debug("Player removed the Redwood Lantern from their inventory.");
 			}
+			removedItems.stream().map(EssencePouches::getPouch).filter(Objects::nonNull).forEach(pouchType -> {
+				if (this.pouches.containsKey(pouchType))
+				{
+					this.pouches.remove(pouchType);
+					log.debug("Player removed {} from their inventory.", pouchType.getName());
+				}
+			});
 			this.previousInventory = currentInventory;
 		}
 		else if (itemContainerChanged.getContainerId() == InventoryID.EQUIPMENT.getId())
@@ -1269,7 +1277,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 		{
 			this.trackingState = trackingState;
 			log.debug("Loaded tracking state: {}", trackingState);
-			for (EssencePouches pouchType : EssencePouches.values())
+			for (EssencePouches pouchType : this.pouches.keySet())
 			{
 				this.pouches.put(pouchType, trackingState.getPouch(pouchType));
 			}
@@ -1297,7 +1305,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 			log.debug("Unable to update the tracking state due to the state being null. Initializing the state.");
 			this.trackingState = new EssencePouchTrackingState();
 			// Initialize the pouches
-			for (EssencePouches pouch : EssencePouches.values())
+			for (EssencePouches pouch : this.pouches.keySet())
 			{
 				this.pouches.put(pouch, this.trackingState.getPouch(pouch));
 			}

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingState.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingState.java
@@ -22,6 +22,11 @@ public class EssencePouchTrackingState
 
 	public EssencePouch getPouch(EssencePouches pouch)
 	{
+		if (pouch == null)
+		{
+			return null;
+		}
+
 		switch (pouch)
 		{
 			case SMALL:
@@ -34,13 +39,19 @@ public class EssencePouchTrackingState
 				return this.giantPouch;
 			case COLOSSAL:
 				return this.colossalPouch;
+			default:
+				return null;
 		}
-		return null;
 	}
 
 	public EssencePouch getPouch(EssencePouch pouch)
 	{
 		return this.getPouch(pouch.getPouchType());
+	}
+
+	public EssencePouch getPouch(int itemID)
+	{
+		return this.getPouch(EssencePouches.getPouch(itemID));
 	}
 
 	public void setPouch(EssencePouch pouch)


### PR DESCRIPTION
# EssencePouchTrackingPlugin
- Expose accessor method for `trackingState` via lombok
- Remove a pouch from pouches map if it was removed from the inventory within #onItemContainerChanged
- When loading the previous tracking state in #loadTrackingState and #updateTrackingState, loop through the current pouches map and update the pouch
	- Prevents adding pouches that aren't in the players inventory into the pouch map

# EssencePouchTrackingState
- Null-check #getPouch(EssencePouches)
- Add #getPouch(Integer) to fetch the essence pouch type via item ID

# EssencePouchTrackingOverlay
- Modify EssencePouchTrackingOverlay#renderItemOverlay to use EssencePouchTrackingState to fetch pouches to render
	- This is due to refactoring the plugin so that the pouches map in the plugin stores the current pouches inside a players inventory

# Preview of behavior

Focus on the debug overlay that lists the pouches. Here, you can see that it lists all 5 available essence pouches in the game.

<details><summary>Before</summary>
<p>

https://github.com/user-attachments/assets/5042f5ff-72f4-41f5-af67-1d483f73c0c8

</p>
</details> 

Focus on the debug overlay that lists the pouches. Here, you can see that it only lists the the available essence pouches in the inventory.

<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/5eefd7ff-e18b-4bee-943f-553c002cf802

</p>
</details> 