### PR TITLE
fix: Prevent updating pouch state if there are unknown stored/decay states

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.3'
+version = '1.5.4'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouch.java
+++ b/src/main/java/essencepouchtracking/EssencePouch.java
@@ -38,6 +38,30 @@ public class EssencePouch
 	}
 
 	/**
+	 * Sets the stored essence in the pouch directly without modifying `remainingEssenceBeforeDecay`
+	 *
+	 * @param storedEssence amount of essence to be stored
+	 */
+	public void setStoredEssence(int storedEssence)
+	{
+		this.storedEssence = storedEssence;
+		this.setUnknownStored(false);
+		log.debug("Setting {} stored essence to {} (previously {})", this.pouchType.getName(), storedEssence, this.storedEssence);
+	}
+
+	/**
+	 * Sets the remaining essence before decay
+	 *
+	 * @param remainingEssenceBeforeDecay amount of essence available to be stored until decay
+	 */
+	public void setRemainingEssenceBeforeDecay(int remainingEssenceBeforeDecay)
+	{
+		this.remainingEssenceBeforeDecay = remainingEssenceBeforeDecay;
+		this.setUnknownDecay(false);
+		log.debug("Setting {} remaining essence before decay to {} (previously {})", this.pouchType.getName(), remainingEssenceBeforeDecay, this.remainingEssenceBeforeDecay);
+	}
+
+	/**
 	 * Repairs the pouch by resetting the essence remaining before decay and resets the degradation state
 	 */
 	public void repairPouch()

--- a/src/main/java/essencepouchtracking/EssencePouch.java
+++ b/src/main/java/essencepouchtracking/EssencePouch.java
@@ -56,6 +56,10 @@ public class EssencePouch
 	 */
 	public int empty(int essenceToRemove)
 	{
+		if (this.isUnknownStored())
+		{
+			return 0;
+		}
 		int previousStoredEssence = this.storedEssence;
 		int essenceRemoved = Math.min(essenceToRemove, this.storedEssence);
 		this.storedEssence -= essenceRemoved;
@@ -82,9 +86,13 @@ public class EssencePouch
 	 */
 	public int fill(int totalEssenceInInventory, boolean ignoreDecay)
 	{
+		if (this.isUnknownStored())
+		{
+			return 0;
+		}
 		int essenceToStore = Math.min(totalEssenceInInventory, this.getAvailableSpace());
 		this.storedEssence += essenceToStore;
-		if (this.shouldDegrade && !ignoreDecay)
+		if (this.shouldDegrade && !ignoreDecay && !this.isUnknownDecay())
 		{
 			this.remainingEssenceBeforeDecay -= essenceToStore;
 		}
@@ -157,7 +165,7 @@ public class EssencePouch
 		return this.storedEssence == 0;
 	}
 
-	public void empty()
+	public void resetStored()
 	{
 		this.storedEssence = 0;
 		this.setUnknownStored(false);

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -733,13 +733,13 @@ public class EssencePouchTrackingPlugin extends Plugin
 		if (varbitChanged.getVarbitId() == 13688 && varbitChanged.getValue() == 0)
 		{
 			// Clear pouches if a new GOTR game has started
-			this.pouches.values().forEach(EssencePouch::empty);
+			this.pouches.values().forEach(EssencePouch::resetStored);
 			this.saveTrackingState();
 		}
 		else if (varbitChanged.getVarbitId() == 13691 && varbitChanged.getValue() == 0)
 		{
 			// Clear pouches if a player leaves the GOTR portal
-			this.pouches.values().forEach(EssencePouch::empty);
+			this.pouches.values().forEach(EssencePouch::resetStored);
 			this.saveTrackingState();
 			log.debug("Player has left the GOTR portal");
 			this.isLanternDecayPreventionAvailable = false;

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -900,6 +900,14 @@ public class EssencePouchTrackingPlugin extends Plugin
 						}
 					}
 				}
+
+				if (pouch.isUnknownStored())
+				{
+					log.debug("{} has an unknown stored essence count. Setting it to {} stored essence.", pouch.getPouchType().getName(), numberOfEssence);
+					pouch.setStoredEssence(numberOfEssence);
+					return;
+				}
+
 				int previousStoredEssence = pouch.getStoredEssence();
 				int difference = numberOfEssence - previousStoredEssence;
 
@@ -923,10 +931,12 @@ public class EssencePouchTrackingPlugin extends Plugin
 					pouch.setStoredEssence(numberOfEssence);
 				}
 				this.updateTrackingState();
+				return;
 			}
 			else
 			{
 				log.debug("Received a check pouch count message, but there was no more pouches in the queue.");
+				return;
 			}
 		}
 

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -435,6 +435,13 @@ public class EssencePouchTrackingPlugin extends Plugin
 		if (pouch == null)
 		{
 			log.debug("Pouch {} not found in pouches map so can't do {}", pouchAction.getPouchType(), pouchAction.getAction());
+			this.pauseUntilTick = -1;
+			return false;
+		}
+		else if (pouch.isUnknownStored())
+		{
+			log.debug("Pouch {} is unknown so can't do {} to avoid improper state", pouchAction.getPouchType(), pouchAction.getAction());
+			this.pauseUntilTick = -1;
 			return false;
 		}
 
@@ -446,12 +453,14 @@ public class EssencePouchTrackingPlugin extends Plugin
 			if (pouch.isFilled())
 			{
 				log.debug("{} is already full so can't fill it", pouchAction.getPouchType());
+				this.pauseUntilTick = -1;
 				return false;
 			}
 			// Now check to see if there's even essence in the inventory
 			if (this.essenceInInventory == 0)
 			{
 				log.debug("No essence in the inventory to fill the {}", pouchAction.getPouchType());
+				this.pauseUntilTick = -1;
 				return false;
 			}
 
@@ -469,12 +478,14 @@ public class EssencePouchTrackingPlugin extends Plugin
 			if (pouch.isEmpty())
 			{
 				log.debug("{} is already empty so can't empty it", pouchAction.getPouchType());
+				this.pauseUntilTick = -1;
 				return false;
 			}
 			// Now check to see if there's even space in the inventory
 			if (this.inventoryFreeSlots == 0)
 			{
 				log.debug("No space in the inventory to empty the {}", pouchAction.getPouchType());
+				this.pauseUntilTick = -1;
 				return false;
 			}
 			// We meet all the conditions required to empty the pouch into the inventory (we have space to empty some if not all, and the pouch isn't empty)

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -903,6 +903,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 				{
 					log.debug("{} has an unknown stored essence count. Setting it to {} stored essence.", pouch.getPouchType().getName(), numberOfEssence);
 					pouch.setStoredEssence(numberOfEssence);
+					this.updateTrackingState();
 					return;
 				}
 


### PR DESCRIPTION
# EssencePouch
- Ignore emptying a pouch and updating the state if the pouch has `unknownStored` in #empty return 0
- Ignore filling a pouch and updating the state if the pouch has `unknownStored` in #fill return 0
- Ignore updating the `remainingEssenceBeforeDecay` state if the pouch also has `unknownDecay`in #fill
- Rename #empty() to #resetStored()

# EssencePouchTrackingPlugin
- Refactor EssencePouch#empty call to EssencePouch#resetStored in #onVarbitChanged