### PR TITLE
feat: Notify users to initialize their pouches (#23)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.4'
+version = '1.5.5'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'


### PR DESCRIPTION
Adds a message to chat notifying users to both check and repair their pouch(es) if applicable in order to initialize the state of a given pouch. Hopefully this will reduce the amount of issues regarding a pouch's state in addition to #37 by telling users to manually manually initialize the pouch state.

> Please check your essence pouch(es) and attempt to repair them to initialize their state(s).

- Sends the message either when
	- The user resets the config
	- The user turns the plugin off/on
	- The user logs in (matches daily tasks plugin behavior*)
		- The same account or a different account
- Sends the message as long as there is at least one pouch with either an unknown essence left until decay count or an unknown stored essence count

Closes #23 and addresses a request from #32