### PR TITLE
fix: No more stuttering with large item stacks in inv (#35)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.5'
+version = '1.5.6'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -581,7 +581,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 			Set<EssencePouches> modifiedEssencePouch = new HashSet<>(EssencePouches.values().length);
 			// Now that we've handling inventory state changes, we can handle the pouches
 			// First check if we have any pouches in the inventory in case this is the user's first run or some other issue
-			for (int itemId : addedItems)
+			for (int itemId : addedItems.elementSet())
 			{
 				EssencePouch pouch = EssencePouches.createPouch(itemId);
 				if (pouch != null && !this.pouches.containsKey(pouch.getPouchType()))
@@ -626,12 +626,12 @@ public class EssencePouchTrackingPlugin extends Plugin
 				}
 			}
 
-			if (removedItems.contains(ItemID.ABYSSAL_LANTERN_REDWOOD_LOGS))
+			if (removedItems.elementSet().contains(ItemID.ABYSSAL_LANTERN_REDWOOD_LOGS))
 			{
 				this.hasRedwoodAbyssalLanternInInventory = false;
 				log.debug("Player removed the Redwood Lantern from their inventory.");
 			}
-			removedItems.stream().map(EssencePouches::getPouch).filter(Objects::nonNull).filter(Predicate.not(modifiedEssencePouch::contains)).forEach(pouchType -> {
+			removedItems.elementSet().stream().map(EssencePouches::getPouch).filter(Objects::nonNull).filter(Predicate.not(modifiedEssencePouch::contains)).forEach(pouchType -> {
 				if (this.pouches.containsKey(pouchType))
 				{
 					this.pouches.remove(pouchType);


### PR DESCRIPTION
fix: No more stuttering with large item stacks in inv

# EssencePouchTrackingPlugin
- Iterate through the #elementSet to only loop through the item id once instead of per occurance in #onItemContainerChanged

I made the mistake of thinking that iterating a `Multiset` would only loop the element itself, like a key in a `Map`. However, it will iterate `n` times as as the size of the Multiset - the total # of occurrences of all elements. As a result, there were stutters when withdrawing items with large quantities such as coins.

Fixes #35