### PR TITLE
fix: Refactor pouch repairs and fix colossal repair (#30)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.6'
+version = '1.5.7'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Multisets;
 import com.google.common.collect.Queues;
 import com.google.gson.Gson;
 import com.google.inject.Provides;
+import essencepouchtracking.pouch.RepairDialog;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
@@ -33,7 +34,6 @@ import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
-import net.runelite.api.NpcID;
 import net.runelite.api.Skill;
 import net.runelite.api.VarClientStr;
 import net.runelite.api.events.AccountHashChanged;
@@ -396,14 +396,14 @@ public class EssencePouchTrackingPlugin extends Plugin
 		{
 			Widget clickedWidget = menuOptionClicked.getWidget();
 			Widget dialogPlayerTextWidget = this.client.getWidget(ComponentID.DIALOG_PLAYER_TEXT);
-			if (clickedWidget != null && dialogPlayerTextWidget != null && clickedWidget.getText().equals(DIALOG_CONTINUE_TEXT) && dialogPlayerTextWidget.getText().equals(REQUEST_REPAIR_PLAYER_DIALOG_TEXT))
+			if (clickedWidget != null && dialogPlayerTextWidget != null && clickedWidget.getText().equals(RepairDialog.DIALOG_CONTINUE_TEXT) && dialogPlayerTextWidget.getText().equals(RepairDialog.REQUEST_REPAIR_PLAYER_DIALOG_TEXT))
 			{
 				this.repairAllPouches();
 			}
 			if (this.didUnlockGOTRRepair)
 			{
 				Widget dialogNPCTextWidget = this.client.getWidget(ComponentID.DIALOG_NPC_TEXT);
-				if (clickedWidget != null && dialogNPCTextWidget != null && clickedWidget.getText().equals(DIALOG_CONTINUE_TEXT) && dialogNPCTextWidget.getText().equals(REQUEST_REPAIR_CORDELIA_DIALOG_TEXT))
+				if (clickedWidget != null && dialogNPCTextWidget != null && clickedWidget.getText().equals(RepairDialog.DIALOG_CONTINUE_TEXT) && dialogNPCTextWidget.getText().equals(RepairDialog.REQUEST_REPAIR_CORDELIA_DIALOG_TEXT))
 				{
 					this.repairAllPouches();
 				}
@@ -700,14 +700,13 @@ public class EssencePouchTrackingPlugin extends Plugin
 			Widget dialogText = this.client.getWidget(ComponentID.DIALOG_NPC_TEXT);
 			if (dialogNPCHeadModel != null && dialogText != null)
 			{
-				if (dialogNPCHeadModel.getModelId() == NpcID.DARK_MAGE && (POST_REPAIR_DARK_MAGE_DIALOG_TEXT.contains(dialogText.getText())
-					|| (this.didUnlockGOTRRepair && dialogText.getText().equals(POST_REPAIR_DARK_MAGE_CORDELIA_DIALOG_TEXT))))
+				if (dialogNPCHeadModel.getModelId() == RepairDialog.DARK_MAGE_WIDGET_MODEL_ID && (RepairDialog.REPAIRED_DARK_MAGE_DIALOG_TEXTS.contains(dialogText.getText())
+					|| (this.didUnlockGOTRRepair && dialogText.getText().equals(RepairDialog.REPAIR_CONFIRMATION_CORDELIA_DARK_MAGE_DIALOG_TEXT))))
 				{
 					this.repairAllPouches();
 				}
 				// Cordelia's NPC ID is 12180 but her model ID when talking to her is 6717
-				if (this.didUnlockGOTRRepair && dialogNPCHeadModel.getModelId() == APPRENTICE_CORDELIA_WIDGET_MODEL_ID && (dialogText.getText().equals(POST_REPAIR_CORDELIA_DIALOG_TEXT)
-					|| dialogText.getText().equals(ALREADY_REPAIRED_CORDELIA_DIALOG_TEXT)))
+				if (this.didUnlockGOTRRepair && dialogNPCHeadModel.getModelId() == RepairDialog.APPRENTICE_CORDELIA_WIDGET_MODEL_ID && RepairDialog.REPAIRED_CORDELIA_DIALOG_TEXTS.contains(dialogText.getText()))
 				{
 					this.repairAllPouches();
 				}
@@ -719,7 +718,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 			if (dialogOptionsWidget != null && dialogOptionsWidget.getChildren() != null)
 			{
 				List<String> options = Arrays.stream(dialogOptionsWidget.getChildren()).filter(Objects::nonNull).map(Widget::getText).collect(Collectors.toList());
-				if (options.equals(ALREADY_REPAIRED_DIALOG_OPTIONS) || options.equals(POST_REPAIR_DIALOG_OPTIONS))
+				if (RepairDialog.POST_REPAIR_DIALOG_OPTIONS.contains(options))
 				{
 					this.repairAllPouches();
 				}
@@ -1096,7 +1095,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 		if (this.isRepairDialogue && postFiredScript.getScriptId() == 2153)
 		{
 			Widget dialogPlayerTextWidget = this.client.getWidget(ComponentID.DIALOG_PLAYER_TEXT);
-			if (dialogPlayerTextWidget != null && dialogPlayerTextWidget.getText().equals(REQUEST_REPAIR_PLAYER_DIALOG_TEXT))
+			if (dialogPlayerTextWidget != null && dialogPlayerTextWidget.getText().equals(RepairDialog.REQUEST_REPAIR_PLAYER_DIALOG_TEXT))
 			{
 				this.repairAllPouches();
 				return;
@@ -1104,7 +1103,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 			if (this.didUnlockGOTRRepair)
 			{
 				Widget dialogNpcTextWidget = this.client.getWidget(ComponentID.DIALOG_NPC_TEXT);
-				if (dialogNpcTextWidget != null && dialogNpcTextWidget.getText().equals(REQUEST_REPAIR_CORDELIA_DIALOG_TEXT))
+				if (dialogNpcTextWidget != null && dialogNpcTextWidget.getText().equals(RepairDialog.REQUEST_REPAIR_CORDELIA_DIALOG_TEXT))
 				{
 					this.repairAllPouches();
 				}

--- a/src/main/java/essencepouchtracking/pouch/RepairDialog.java
+++ b/src/main/java/essencepouchtracking/pouch/RepairDialog.java
@@ -1,0 +1,117 @@
+package essencepouchtracking.pouch;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
+import net.runelite.api.NpcID;
+
+public class RepairDialog
+{
+
+	private static class Regular
+	{
+		// Regular Essence Pouches via Dark Mage
+		// Already repaired pouch dialog options via Dark Mage
+		private static final List<String> ALREADY_REPAIRED_DARK_MAGE_DIALOG_OPTIONS = ImmutableList.of("Select an option", "Can I have another Abyssal book?", "Actually, I don't need anything right now.", "", "");
+		// Degraded pouch dialog options via Dark Mage
+		private static final List<String> PRE_REPAIR_DARK_MAGE_DIALOG_OPTIONS = ImmutableList.of("Select an option", "Can I have another Abyssal book?", "Can you repair my pouches?", "Actually, I don't need anything right now.", "", "");
+		private static final String REPAIR_CONFIRMATION_DIALOG_TEXT = "Fine. A simple transfiguration spell should resolve things<br>for you.";
+		private static final List<String> POST_REPAIR_DIALOG_OPTIONS = ImmutableList.of("Select an option", "Can I have another Abyssal book?", "Thanks.", "", "");
+		// Already repaired pouch NPC dialog text via Dark Mage Menu Interaction (Right-click "Repair")
+		private static final String ALREADY_REPAIRED_DARK_MAGE_DIALOG_TEXT = "You don't seem to have any pouches in need of repair.<br>Leave me alone!";
+		// Degraded pouch NPC dialog text via Dark Mage Menu Interaction (Right-click "Repair")
+		private static final String POST_REPAIR_DARK_MAGE_DIALOG_TEXT = "There, I have repaired your pouches. Now leave me<br>alone. I'm concentrating!";
+
+		// Regular Essence Pouches via Apprentice Cordelia
+		// Already repaired pouch dialog options via Apprentice Cordelia (Any interaction)
+		public static final String ALREADY_REPAIRED_CORDELIA_DIALOG_TEXT = "You don't seem to have any pouches in need of repair.";
+		// Degraded pouch dialog options via Apprentice Cordelia (Any interaction)
+		private static final String PRE_REPAIR_CORDELIA_DIALOG_TEXT = "I got someone here in need of a pouch repair."; // Cordelia
+		public static final String REPAIR_CONFIRMATION_CORDELIA_DARK_MAGE_DIALOG_TEXT = "OK...It's done."; // Dark Mage
+		public static final String POST_REPAIR_CORDELIA_DIALOG_TEXT = "Your pouches have been repaired."; // Cordelia
+	}
+
+	private static class Colossal
+	{
+		// Colossal Essence Pouch via Dark Mage
+		// Already repaired pouch dialog options via Dark Mage
+		private static final List<String> ALREADY_REPAIRED_DARK_MAGE_DIALOG_OPTIONS = ImmutableList.of("Select an option", "Can I have another Abyssal book?", "Can I have a new essence pouch?", "Actually, I don't need anything right now.", "", "");
+		// Degraded pouch dialog options via Dark Mage
+		private static final List<String> PRE_REPAIR_DARK_MAGE_DIALOG_OPTIONS = ImmutableList.of("Select an option", "Can I have another Abyssal book?", "Can you repair my pouches?", "Can I have a new essence pouch?", "Actually, I don't need anything right now.", "", "");
+		private static final String REPAIR_CONFIRMATION_DIALOG_TEXT = "Fine. A simple transfiguration spell should resolve things<br>for you.";
+		private static final List<String> POST_REPAIR_DIALOG_OPTIONS = ImmutableList.of("Select an option", "Can I have another Abyssal book?", "Can I have a new essence pouch?", "Thanks.", "", "");
+		// Already repaired pouch NPC dialog text via Dark Mage Menu Interaction (Right-click "Repair")
+		private static final String ALREADY_REPAIRED_DARK_MAGE_DIALOG_TEXT = "You don't seem to have any pouches in need of repair.<br>Leave me alone!";
+		// Degraded pouch NPC dialog text via Dark Mage Menu Interaction (Right-click "Repair")
+		private static final String POST_REPAIR_DARK_MAGE_DIALOG_TEXT = "There, I have repaired your pouches. Now leave me<br>alone. I'm concentrating!";
+
+		// Colossal Essence Pouch via Apprentice Cordelia
+		// Already repaired pouch dialog options via Apprentice Cordelia (Any interaction)
+		private static final String ALREADY_REPAIRED_CORDELIA_DIALOG_TEXT = "You don't seem to have any pouches in need of repair.";
+		// Degraded pouch dialog options via Apprentice Cordelia (Any interaction)
+		private static final String PRE_REPAIR_CORDELIA_DIALOG_TEXT = "I got someone here in need of a pouch repair."; // Cordelia
+		private static final String REPAIR_CONFIRMATION_CORDELIA_DARK_MAGE_DIALOG_TEXT = "OK...It's done."; // Dark Mage
+		private static final String POST_REPAIR_CORDELIA_DIALOG_TEXT = "Your pouches have been repaired."; // Cordelia
+	}
+
+	/**
+	 * The model ID of the Dark Mage NPC widget
+	 */
+	public static final int DARK_MAGE_WIDGET_MODEL_ID = NpcID.DARK_MAGE;
+
+	/**
+	 * The model ID of the Apprentice Cordelia NPC widget
+	 * Cordelia's NPC ID is 12180 but her model ID when talking to her is 6717
+	 */
+	public static final int APPRENTICE_CORDELIA_WIDGET_MODEL_ID = 6717;
+
+	/**
+	 * The dialog text of the player requesting the Dark Mage to repair their pouches.
+	 * As soon as the player confirms the dialog, the NPC will repair the pouches instantly.
+	 */
+	public static final String REQUEST_REPAIR_PLAYER_DIALOG_TEXT = "Can you repair my pouches?";
+
+	/**
+	 * The dialog text of the player requesting Apprentice Cordelia to repair their pouches.
+	 * As soon as the player confirms the dialog, the NPC will repair the pouches instantly.
+	 */
+	public static final String REQUEST_REPAIR_CORDELIA_DIALOG_TEXT = "I got someone here in need of a pouch repair.";
+
+	/**
+	 * The text of the continue widget that appears in dialogs, typically in conversational dialog text
+	 */
+	public static final String DIALOG_CONTINUE_TEXT = "Click here to continue";
+
+	/**
+	 * Set of all dialog texts by the Dark Mage that indicate the player has or had already repaired their pouches
+	 */
+	public static final Set<String> REPAIRED_DARK_MAGE_DIALOG_TEXTS = ImmutableSet.of(
+		Regular.REPAIR_CONFIRMATION_DIALOG_TEXT,
+		Regular.POST_REPAIR_DARK_MAGE_DIALOG_TEXT,
+		Regular.ALREADY_REPAIRED_DARK_MAGE_DIALOG_TEXT
+	);
+
+	/**
+	 * Set of all dialog options by the Dark Mage that indicate the player has or had already repaired their pouches
+	 */
+	public static final Set<String> POST_REPAIR_DIALOG_OPTIONS = ImmutableSet.<String>builder()
+		.addAll(Regular.ALREADY_REPAIRED_DARK_MAGE_DIALOG_OPTIONS)
+		.addAll(Colossal.ALREADY_REPAIRED_DARK_MAGE_DIALOG_OPTIONS)
+		.addAll(Regular.POST_REPAIR_DIALOG_OPTIONS)
+		.addAll(Colossal.POST_REPAIR_DIALOG_OPTIONS)
+		.build();
+
+	/**
+	 * The dialog text by the Dark Mage that indicates the player has repaired their pouches
+	 */
+	public static final String REPAIR_CONFIRMATION_CORDELIA_DARK_MAGE_DIALOG_TEXT = Regular.REPAIR_CONFIRMATION_CORDELIA_DARK_MAGE_DIALOG_TEXT;
+
+	/**
+	 * Set of all dialog texts by Apprentice Cordelia that indicate the player has or had already repaired their pouches
+	 */
+	public static final Set<String> REPAIRED_CORDELIA_DIALOG_TEXTS = ImmutableSet.of(
+		Regular.ALREADY_REPAIRED_CORDELIA_DIALOG_TEXT,
+		Regular.POST_REPAIR_CORDELIA_DIALOG_TEXT
+	);
+}

--- a/src/main/java/essencepouchtracking/pouch/RepairDialog.java
+++ b/src/main/java/essencepouchtracking/pouch/RepairDialog.java
@@ -95,12 +95,12 @@ public class RepairDialog
 	/**
 	 * Set of all dialog options by the Dark Mage that indicate the player has or had already repaired their pouches
 	 */
-	public static final Set<String> POST_REPAIR_DIALOG_OPTIONS = ImmutableSet.<String>builder()
-		.addAll(Regular.ALREADY_REPAIRED_DARK_MAGE_DIALOG_OPTIONS)
-		.addAll(Colossal.ALREADY_REPAIRED_DARK_MAGE_DIALOG_OPTIONS)
-		.addAll(Regular.POST_REPAIR_DIALOG_OPTIONS)
-		.addAll(Colossal.POST_REPAIR_DIALOG_OPTIONS)
-		.build();
+	public static final Set<List<String>> POST_REPAIR_DIALOG_OPTIONS = ImmutableSet.of(
+		Regular.ALREADY_REPAIRED_DARK_MAGE_DIALOG_OPTIONS,
+		Colossal.ALREADY_REPAIRED_DARK_MAGE_DIALOG_OPTIONS,
+		Regular.POST_REPAIR_DIALOG_OPTIONS,
+		Colossal.POST_REPAIR_DIALOG_OPTIONS
+	);
 
 	/**
 	 * The dialog text by the Dark Mage that indicates the player has repaired their pouches


### PR DESCRIPTION
Refactored handling pouch repairing dialogs and fix colossal essence pouches not being marked as repaired due to some missing dialog text/options

# Tests

## Regular Essence Pouches
### Dark Mage
- [x] Degraded pouch via NPC Contact
- [x] Already repaired via NPC Contact
- [x] Degraded pouch via Abyss (Talk-to)
- [x] Already repaired via Abyss (Talk-to)
- [x] Degraded pouch via Abyss (Repair)
- [x] Already repaired via Abyss (Repair)

### Apprentice Cordelia
- [x] Degraded pouch via Cordelia (Talk-to)
- [x] Already repaired via Cordelia (Talk-to)
- [x] Degraded pouch via Cordelia (Repair)
- [x] Already repaired via Cordelia  (Repair)

## Colossal Essence Pouch
### Dark Mage
- [x] Degraded pouch via NPC Contact
- [x] Already repaired via NPC Contact
- [x] Degraded pouch via Abyss (Talk-to)
- [x] Already repaired via Abyss (Talk-to)
- [x] Degraded pouch via Abyss (Repair)
- [x] Already repaired via Abyss (Repair)

### Apprentice Cordelia
- [x] Degraded pouch via Cordelia (Talk-to)
- [x] Already repaired via Cordelia (Talk-to)
- [x] Degraded pouch via Cordelia (Repair)
- [x] Already repaired via Cordelia  (Repair)
