### PR TITLE
feat: Support state resets when up/downgrading pouches (#43)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.7'
+version = '1.5.8'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouch.java
+++ b/src/main/java/essencepouchtracking/EssencePouch.java
@@ -194,4 +194,16 @@ public class EssencePouch
 		this.storedEssence = 0;
 		this.setUnknownStored(false);
 	}
+
+	public void resetDecay()
+	{
+		this.remainingEssenceBeforeDecay = this.pouchType.getMaxEssenceBeforeDecay();
+		this.setUnknownDecay(false);
+	}
+
+	public void reset()
+	{
+		this.resetStored();
+		this.resetDecay();
+	}
 }

--- a/src/main/java/essencepouchtracking/EssencePouches.java
+++ b/src/main/java/essencepouchtracking/EssencePouches.java
@@ -1,13 +1,14 @@
 package essencepouchtracking;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import net.runelite.api.ItemID;
-
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Getter
 @AllArgsConstructor
@@ -89,6 +90,8 @@ public enum EssencePouches
 		DEGRADED_ESSENCE_POUCHES_MAP = degradedPouchesBuilder.build();
 	}
 
+	public static final Set<EssencePouches> REGULAR_ESSENCE_POUCHES = ImmutableSet.of(SMALL, MEDIUM, LARGE, GIANT);
+
 	public static EssencePouches getPouch(int itemID)
 	{
 		return ESSENCE_POUCHES_MAP.containsKey(itemID) ? ESSENCE_POUCHES_MAP.get(itemID) : DEGRADED_ESSENCE_POUCHES_MAP.get(itemID);
@@ -145,5 +148,27 @@ public enum EssencePouches
 			return number != null ? number : -1;
 		}
 		return -1;
+	}
+
+	/**
+	 * Checks if the itemID is a regular essence pouch type
+	 *
+	 * @param itemID The itemID to check
+	 * @return true if the itemID is a regular essence pouch type
+	 */
+	public static boolean isARegularEssencePouch(int itemID)
+	{
+		return !isAColossalEssencePouch(itemID);
+	}
+
+	/**
+	 * Checks if the itemID is a colossal essence pouch type
+	 *
+	 * @param itemID The itemID to check
+	 * @return true if the itemID is a colossal essence pouch type
+	 */
+	public static boolean isAColossalEssencePouch(int itemID)
+	{
+		return itemID == COLOSSAL.getItemID() || itemID == COLOSSAL.getDegradedItemID();
 	}
 }


### PR DESCRIPTION
# EssencePouchTrackingPlugin
- Listen for Regular Pouches <-> Colossal switches and reset state respectively in #onItemContainerChanged
	- Added #upgradedToColossalPouch to reset the state of all regular pouches
	- Added #downgradedToRegularPouch to reset the state of the colossal pouch

# EssencePouch
- Add #resetDecay to reset the essence remaining until decay for the pouch
- Add #reset to reset the stored and decay essence states of the pouch

# EssencePouches
- Add `REGULAR_ESSENCE_POUCHES` to expose a Set of regular essence pouches
- Add #isARegularEssencePouch to check if an item id is associated with a regular essence pouch
- Add #isAColossalEssencePouch to check if an item id is associated with a colossal essence pouch

Closes #43