### PR TITLE
fix: Use tracking state for bank rendering (#45)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.8'
+version = '1.5.9'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingOverlay.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingOverlay.java
@@ -5,7 +5,6 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.util.Map;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.widgets.ComponentID;
@@ -31,14 +30,13 @@ public class EssencePouchTrackingOverlay extends WidgetItemOverlay
 	@Override
 	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem)
 	{
-		Map<EssencePouches, EssencePouch> pouches = this.plugin.getPouches();
-
-		if (pouches.isEmpty() || !(this.config.showStoredEssence() || this.config.showDecay()))
+		EssencePouchTrackingState trackingState = this.plugin.getTrackingState();
+		if (trackingState == null || !(this.config.showStoredEssence() || this.config.showDecay()))
 		{
 			return;
 		}
 
-		EssencePouch pouch = this.plugin.getTrackingState().getPouch(itemId);
+		EssencePouch pouch = trackingState.getPouch(itemId);
 		if (pouch != null)
 		{
 			if (this.config.showStoredEssence())


### PR DESCRIPTION
After #36 pouches were removed from the `pouches` map as they were removed from the players inventory. Therefore, when a player has no pouches in their inventory, the pouch overlay wasn't rendering over the pouches in the bank because `pouches` was empty and early returning out of EssencePouchTrackingOverlay#renderItemOverlay. Using `EssencePouchTrackingState` instead of `pouches` and this resolves the issue and closes #45.