### PR TITLE
fix: Incorrect state due to deposit essence edge case (#47)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.9'
+version = '1.5.10'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'


### PR DESCRIPTION
Fixed an issue where depositing more essence than you had from your inventory to the bank resulted in negative essence stored in your inventory and later broke the state of pouches with an incorrect stored/decay count.

# EssencePouchTrackingPlugin

- Resolved checkstyle warnings with anonymous/lambda functions
- Modified logging output for withdraw/depositing within #onMenuOptionClicked
- Modified and added more logging for #onBankEssenceTaskCreated
- Take the min(quantity, essenceInInventory) when depositing to bank within #onBankEssenceTaskCreated

Closes #47 