### PR TITLE
fix: double pouch actions in bank issuing wrong state (#39)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.10'
+version = '1.5.11'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -348,6 +348,12 @@ public class EssencePouchTrackingPlugin extends Plugin
 						this.pouchTaskQueue.add(pouchTask);
 						log.debug("Added {} task to queue: {}", pouchTask, this.pouchTaskQueue);
 					}
+					log.debug("Was the {} task successful? {}", menuOption, wasActionSuccessful);
+					if (!wasActionSuccessful && this.client.getWidget(ComponentID.BANK_CONTAINER) != null)
+					{
+						log.debug("Failed to {} the {} therefore consuming the click", menuOption, pouchType);
+						menuOptionClicked.consume();
+					}
 				}
 				else if (menuOption.equals("check"))
 				{
@@ -416,7 +422,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 			this.previousInventoryFreeSlots, this.inventoryFreeSlots,
 			this.previousInventoryUsedSlots, this.inventoryUsedSlots
 		);
-		log.debug("{}", this.pouchTaskQueue);
+		log.debug("Task Queue: {}", this.pouchTaskQueue);
 		// List of possible tasks:
 		// 1. Fill pouch
 		// What could happen when we try to fill a pouch?


### PR DESCRIPTION
Fixes the issue where when attempting to do double+ of the same pouch action, RuneScape would reverse it and act as if it never happened (See #39).

# EssencePouchTrackingPlugin
- If the bank is open and a PouchActionTask was unsuccessful then consume the click
	- Since this issue is known to happen while banking, I'm only doing this while banking
- Modified logging to make it more verbose

Closes #39 