### PR TITLE
feat: Add support for colossal pouch at lower RC levels (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A RuneLite plugin that tracks both the amount of essence stored in your essence 
 [!Preview](https://github.com/user-attachments/assets/4e704127-92ea-4daf-976c-ae24dc29d8da)
 
 ## Features
-- Supports all essence kinds of essence and essence pouches
+- Supports all essence kinds of essence and essence pouches (including colossal pouch pre-85 Runecrafting)
 - Shows the amount of essence stored in the essence pouch
 - Shows the amount of essence until the decay
 - Tracks repairing pouches via [Dark Mage](https://oldschool.runescape.wiki/w/Dark_Mage_(Abyss)) (Abyss or NPC Contact) or GOTR's [Apprentice Cordelia](https://oldschool.runescape.wiki/w/Apprentice_Cordelia#Raiments_of_the_Eye)
@@ -22,11 +22,17 @@ A RuneLite plugin that tracks both the amount of essence stored in your essence 
 
 If you have any troubles, try to reset the plugin and re-check and repair your pouches once more. If you still have any problems, please feel free to open an issue on the [GitHub repository](https://github.com/Infinitay/essence-pouch-tracker/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) and be as descriptive as possible.
 ## Known Issues
+### Most issues should resolvable by rechecking your pouches and potentially moving around an item within your inventory. If that doesn't help, then attempt to reset the plugin within the plugin settings.
 
- - _Stored count essence **could** be wrong_
+ - _Stored count for an essence pouch **could** be wrong_
    - There were some rare instances in which the stored count **could** be wrong. After hours of testing, I've faced it perhaps once or twice, and one of them was in a 4+ hour session.
+   - For example, when you have more essence in your inventory than **plugin thinks you can store into a pouch**, and especially if you do multiple of the same actions on that incorrect pouch.
+     - [Click here to view an example video](https://github.com/user-attachments/assets/24be6edf-f9f7-48ca-8680-bd6f1e50fb52). Take note at the numbers after "COLOSSAL" the first is the stored amount, followed by the max allowed and max decay amounts.
+       - When I first fill the pouch, I double-clicked to fill it. So it's trying to fill 15 essence into a pouch that can hold 8. However, the game lets us store more and so the pouch state is incorrect. So all the essence is in the pouch but the state shows the maximum of 8 still. The second click is still registered and so it subtracts what it thinks as 7 essence in our inventory (15-8=7) and tries to add it into our pouch again, however the max allowed is still 8 so it'll "subtract" the essence from our inventory so now we'll have 0 essence. That way when we empty the pouch, the incorrect stored amount of 8 will be subtracted from the pouch amount and instead added to the essence count within our inventory.
+       - In the second example, I only click to fill it once. You can see the same incorrect behavior happening. However, you can also clearly see that the plugin state thinks that the essence within the inventory is 7 even though there is no essence in the inventory. That way, when the playe empties the pouch, it'll subtract the incorrect amount of 8 and add it to the inventory (8+7), and the state will be correct again.
  - Different essence types are not tracked separately
    - This is a feature I'm working on supporting in the future (See [#12](https://github.com/Infinitay/essence-pouch-tracker/issues/12))
+ - Consecutive pouch degradations that result in further reduction of storable essence won't be tracked properly. For example, if your pouch degrades twice and you lose a total extra space of 10, it'll only recognize the initial degradation and think you only have 5 less available.
 
 ## What's Different?
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.5.11'
+version = '1.6.0'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingDebugOverlay.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingDebugOverlay.java
@@ -73,7 +73,7 @@ public class EssencePouchTrackingDebugOverlay extends OverlayPanel
 			for (Map.Entry<EssencePouches, EssencePouch> entry : pouches.entrySet())
 			{
 				EssencePouch pouch = entry.getValue();
-				buildLine(entry.getKey().toString(), String.valueOf(pouch.getStoredEssence()));
+				buildLine(entry.getKey().toString(), String.valueOf(pouch.getStoredEssence()) + "(" + pouch.getMaximumCapacity() + " " + pouch.getMaxDegradedCapacity() + ")");
 			}
 		}
 		return super.render(graphics);

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingPlugin.java
@@ -277,7 +277,7 @@ public class EssencePouchTrackingPlugin extends Plugin
 		//TODO All essence is removed from a pouch when it is dropped
 
 		// Keep in mind that the current inventory will be updated after this event so if the event is fill now and you have 10 essence in your inventory, the inventory will be updated to 0 after this event
-//		ItemContainer currentInventoryContainer = this.getInventoryContainer();
+		// ItemContainer currentInventoryContainer = this.getInventoryContainer();
 
 		if (menuOptionClicked.getMenuAction().equals(MenuAction.CC_OP) || menuOptionClicked.getMenuAction().equals(MenuAction.CC_OP_LOW_PRIORITY))
 		{
@@ -359,6 +359,12 @@ public class EssencePouchTrackingPlugin extends Plugin
 				if (menuOption.equals("fill") || menuOption.equals("empty"))
 				{
 					PouchActionTask pouchTask = new PouchActionTask(pouchType, menuOption, this.client.getTickCount());
+					if (this.delayTicksUntilLevelsInitialized > 0)
+					{
+						log.debug("The player attempted to {} a pouch. Delaying the task until the player's levels are initialized", pouchTask.getAction());
+						menuOptionClicked.consume();
+						return;
+					}
 					boolean wasActionSuccessful = onPouchActionCreated(new PouchActionCreated(pouchTask));
 					if (wasActionSuccessful || this.lastCraftRuneTick != -1)
 					{

--- a/src/main/java/essencepouchtracking/EssencePouches.java
+++ b/src/main/java/essencepouchtracking/EssencePouches.java
@@ -107,7 +107,7 @@ public enum EssencePouches
 		return DEGRADED_ESSENCE_POUCHES_MAP.containsKey(itemID);
 	}
 
-	public static EssencePouch createPouch(int itemID)
+	public static EssencePouch createPouch(int itemID, int runecraftingLevel)
 	{
 		EssencePouch essencePouch = null;
 		EssencePouches pouchType = getPouch(itemID);
@@ -118,11 +118,11 @@ public enum EssencePouches
 
 		if (pouchType.degradedItemID != itemID)
 		{
-			essencePouch = new EssencePouch(pouchType);
+			essencePouch = new EssencePouch(pouchType, runecraftingLevel);
 		}
 		else
 		{
-			essencePouch = new EssencePouch(pouchType);
+			essencePouch = new EssencePouch(pouchType, runecraftingLevel);
 			essencePouch.setDegraded(true);
 			essencePouch.setRemainingEssenceBeforeDecay(Integer.MIN_VALUE);
 		}


### PR DESCRIPTION
Adds support to track colossal pouches at lower levels after the **new OSRS game update** on November 13th 2024 as a part of the GOTR changes that allows using a colossal pouch starting at level 25 Runecrafting. 

See https://oldschool.runescape.wiki/w/Colossal_pouch#Capacity

# EssencePouch
- Add new properties `maxCapacity` and `maxDegradedCapacity` to track the maximum base capacities for a pouch
- Refactored constructors to take in `runecraftingLevel` parameter
- Refactored #getMaximumCapacity to use the new properties to determine the current maximum storable capacity for a pouch
- Add #updateMaxCapacity that updates the base maximum storable capacity of a pouch based on pouch type & runecrafting level
- Add #updateMaxDegradedCapacity that updates the base maximum degraded capacity of a pouch based on pouch type & runecrafting level
	- No still no support for additional degrades post initial degradation

# EssencePouches
- Refactored #createPouch to take in `runecraftingLevel` parameter

# EssencePouchTrackingPlugin
- Add `currentRCLevel` property to track the player's current runecrafting level
- Add #getRunecraftingLevel helper method to get a player's current non-boosted runecrafting level
- Added Runecrafting level checks within #onFakeXpDrop & #onStatChanged
	- Update a colossal pouch's `maxCapacity` and `maxDegradedCapacity` whenever their level changes at all
- Added a chat command `!savecolo` to test state migrating to the newly added `maxCapacity` property
- Added new EssencePouch properties migration checks within #loadTrackingState & #updatePouchFromState
	- In case a user is coming from a version prior to these changes, it'll properly display the pouch state without them having to interact with it to re-initialize the new state with the new properties.
- Initialize colossal pouches within the initialization scope of #updateTrackingState to init. the new properties
- Modified #updatePouchFromState to set the pouch's `isDegraded` value from the state to whatever the current pouch's value is instead
	- Fixes an issue with outdated states such as when the saved state has the pouch as not degraded, but the current pouch in the inventory is in fact degraded

# EssencePouchTrackingDebugOverlay
- Updated overlay panel to display an EssencePouch's #getMaximumQuantity & #getMaxDegradedCapacity