### PR TITLE
fix: Proper colossal pouch maxDegradedCapacity at lower RC levels (#55)

### DIFF
--- a/src/main/java/essencepouchtracking/EssencePouch.java
+++ b/src/main/java/essencepouchtracking/EssencePouch.java
@@ -249,15 +249,18 @@ public class EssencePouch
 			}
 			else if (runecraftingLevel >= 75)
 			{
-				this.maxDegradedCapacity = 27 - 5;
+				int degradeDelta = EssencePouches.GIANT.getMaxCapacity() - EssencePouches.GIANT.getMaxInitialDegradedCapacity(); // 3
+				this.maxDegradedCapacity = 27 - degradeDelta; // 24
 			}
 			else if (runecraftingLevel >= 50)
 			{
-				this.maxDegradedCapacity = 16 - 5;
+				int degradeDelta = EssencePouches.LARGE.getMaxCapacity() - EssencePouches.LARGE.getMaxInitialDegradedCapacity(); // 2
+				this.maxDegradedCapacity = 16 - degradeDelta; // 14
 			}
 			else
 			{
-				this.maxDegradedCapacity = 8 - 5;
+				int degradeDelta = EssencePouches.MEDIUM.getMaxCapacity() - EssencePouches.MEDIUM.getMaxInitialDegradedCapacity(); // 3
+				this.maxDegradedCapacity = 8 - degradeDelta; // 5
 			}
 			if (runecraftingLevel < 85)
 			{

--- a/src/main/java/essencepouchtracking/EssencePouches.java
+++ b/src/main/java/essencepouchtracking/EssencePouches.java
@@ -124,7 +124,7 @@ public enum EssencePouches
 		{
 			essencePouch = new EssencePouch(pouchType, runecraftingLevel);
 			essencePouch.setDegraded(true);
-			essencePouch.setRemainingEssenceBeforeDecay(Integer.MIN_VALUE);
+			essencePouch.setRemainingEssenceBeforeDecay(0);
 		}
 
 		return essencePouch;


### PR DESCRIPTION
# EssencePouch
- Fixed incorrect degraded values within updateMaxDegradedCapacity for colossal pouches at a lower Runecrafting level (<85)