### PR TITLE
feat: Add ability to only show Colossal pouch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 _This project is no longer being maintained due to a recent [OSRS update](https://secure.runescape.com/m=news/run-energy-changes?oldschool=1) which re-exposed the vars for essence pouch data. As a result, RuneLite maintainers have updated their default Runecrafting plugin and this plugin is no longer needed._
+
+_I will leave the plugin still available as it was requested, and some preferred the design of using clicks instead of waiting for ticks, and as of now it seems that OSRS isn't transmitting the data for the colossal pouch, so this plugin can function for just the colossal pouch if need be._
 # [Essence Pouch Tracker](https://runelite.net/plugin-hub/show/essence-pouch-tracking)
 
 ![image](https://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/essence-pouch-tracking)

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'essencepouchtracking'
-version = '1.6.1'
+version = '1.6.2'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingConfig.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingConfig.java
@@ -10,10 +10,21 @@ public interface EssencePouchTrackingConfig extends Config
 	String GROUP = "essencepouchtracking";
 
 	@ConfigItem(
+		keyName = "showOnlyColossal",
+		name = "Colossal Pouch Only",
+		description = "Only shows the overlays for the Colossal Pouch",
+		position = 0
+	)
+	default boolean showOnlyColossal()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "showStoredEssence",
 		name = "Show Stored",
 		description = "Shows the amount of stored essence over the essence pouch",
-		position = 0
+		position = 1
 	)
 	default boolean showStoredEssence()
 	{
@@ -24,7 +35,7 @@ public interface EssencePouchTrackingConfig extends Config
 		keyName = "showDecay",
 		name = "Show Decay",
 		description = "Shows the approx. amount of essence able to be stored before the essence pouch decays",
-		position = 1
+		position = 2
 	)
 	default boolean showDecay()
 	{
@@ -35,7 +46,7 @@ public interface EssencePouchTrackingConfig extends Config
 		keyName = "showDebugOverlay",
 		name = "Show Debug Overlay",
 		description = "Shows the debug overlay",
-		hidden = true,
+		hidden = false,
 		position = Integer.MAX_VALUE
 	)
 	default boolean showDebugOverlay()

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingConfig.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingConfig.java
@@ -46,7 +46,7 @@ public interface EssencePouchTrackingConfig extends Config
 		keyName = "showDebugOverlay",
 		name = "Show Debug Overlay",
 		description = "Shows the debug overlay",
-		hidden = false,
+		hidden = true,
 		position = Integer.MAX_VALUE
 	)
 	default boolean showDebugOverlay()

--- a/src/main/java/essencepouchtracking/EssencePouchTrackingOverlay.java
+++ b/src/main/java/essencepouchtracking/EssencePouchTrackingOverlay.java
@@ -39,6 +39,11 @@ public class EssencePouchTrackingOverlay extends WidgetItemOverlay
 		EssencePouch pouch = trackingState.getPouch(itemId);
 		if (pouch != null)
 		{
+			if (this.config.showOnlyColossal() && pouch.getPouchType() != EssencePouches.COLOSSAL)
+			{
+				return;
+			}
+
 			if (this.config.showStoredEssence())
 			{
 				renderStoredEssence(graphics, itemId, widgetItem, pouch);


### PR DESCRIPTION
After deprecating the plugin, some users wanted to still use the plugin either because they liked the _tick-perfect_ inferencing and/or because currently OSRS apparently doesn't transmit the data for the Colossal Pouch's degradation state. As a result, I am adding a config option that will allow users to choose to render the overlay(s) over only the Colossal Pouch or not.